### PR TITLE
Add component tree view

### DIFF
--- a/src/spyAgent/Communicator.java
+++ b/src/spyAgent/Communicator.java
@@ -50,6 +50,9 @@ public class Communicator {
                     StepRecorder.start();
                 } else if ("STOP_REC".equalsIgnoreCase(line)) {
                     StepRecorder.stop();
+                } else if (line.startsWith("HIGHLIGHT,")) {
+                    String loc = line.substring("HIGHLIGHT,".length());
+                    ComponentLocatorStore.highlight(loc);
                 }
             }
         } catch (IOException e) {

--- a/src/spyAgent/CompEnum.java
+++ b/src/spyAgent/CompEnum.java
@@ -43,8 +43,11 @@ public class CompEnum implements Runnable {
         }
 
         Communicator.writeToServer("Started Indexing Components");
+        ComponentLocatorStore.clear();
+        Communicator.writeToServer("TREE_BEGIN");
         ListComponent compList = new ListComponent(hieMap);
         compList.listComponentsInContext(component);
+        Communicator.writeToServer("TREE_END");
         Communicator.writeToServer("Finished Indexing Components");
 
     }

--- a/src/spyAgent/ComponentLocatorStore.java
+++ b/src/spyAgent/ComponentLocatorStore.java
@@ -1,0 +1,44 @@
+package spyAgent;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.*;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ComponentLocatorStore {
+    private static final Map<String, Component> map = new ConcurrentHashMap<>();
+    private static Component highlighted;
+
+    public static void clear() {
+        map.clear();
+        highlighted = null;
+    }
+
+    public static void put(String locator, Component comp) {
+        map.put(locator, comp);
+    }
+
+    public static void highlight(String locator) {
+        Component comp = map.get(locator);
+        if (comp == null) {
+            return;
+        }
+        SwingUtilities.invokeLater(() -> {
+            if (highlighted != null && highlighted != comp) {
+                MouseEvent exitEvt = new MouseEvent(highlighted, MouseEvent.MOUSE_EXITED,
+                        System.currentTimeMillis(), 0, 0, 0, 0, false);
+                for (MouseListener ml : highlighted.getMouseListeners()) {
+                    ml.mouseExited(exitEvt);
+                }
+            }
+            highlighted = comp;
+            MouseEvent enterEvt = new MouseEvent(comp, MouseEvent.MOUSE_ENTERED,
+                    System.currentTimeMillis(), 0, 0, 0, 0, false);
+            for (MouseListener ml : comp.getMouseListeners()) {
+                ml.mouseEntered(enterEvt);
+            }
+        });
+    }
+}
+

--- a/src/spyAgent/ListComponent.java
+++ b/src/spyAgent/ListComponent.java
@@ -62,6 +62,7 @@ public class ListComponent {
         public void operateOnComponent(Component component, int level) {
             componentName = componentToString(component);
             componentClass = myHieMap.getInstance(component);
+            String locator = StepRecorder.getLocator(component);
             CompMouseListner mouseListner = new CompMouseListner(myHieMap.index, level, myHieMap.winTitle, componentClass, myHieMap.props);
 
             for (MouseListener ml : component.getMouseListeners()) {
@@ -70,6 +71,8 @@ public class ListComponent {
                 }
             }
             component.addMouseListener(mouseListner);
+            ComponentLocatorStore.put(locator, component);
+            Communicator.writeToServer("TREE," + level + "," + locator);
         }
     }
 

--- a/src/spyGui/ComponentTreePane.java
+++ b/src/spyGui/ComponentTreePane.java
@@ -1,0 +1,74 @@
+package spyGui;
+
+import javax.swing.*;
+import javax.swing.tree.*;
+import javax.swing.event.*;
+import java.awt.*;
+import java.util.*;
+
+public class ComponentTreePane extends JPanel {
+    private static final long serialVersionUID = 1L;
+
+    private final DefaultMutableTreeNode root = new DefaultMutableTreeNode("Components");
+    private final DefaultTreeModel model = new DefaultTreeModel(root);
+    private final JTree tree = new JTree(model);
+    private final java.util.List<DefaultMutableTreeNode> stack = new ArrayList<>();
+
+    public ComponentTreePane() {
+        setLayout(new BorderLayout());
+        add(new JScrollPane(tree), BorderLayout.CENTER);
+        tree.addTreeSelectionListener(new TreeSelectionListener() {
+            @Override
+            public void valueChanged(TreeSelectionEvent e) {
+                DefaultMutableTreeNode node = (DefaultMutableTreeNode) tree.getLastSelectedPathComponent();
+                if (node == null) {
+                    return;
+                }
+                Object obj = node.getUserObject();
+                if (obj instanceof NodeData) {
+                    String loc = ((NodeData) obj).locator;
+                    SpyClientReader.sendCommand("HIGHLIGHT," + loc);
+                }
+            }
+        });
+    }
+
+    public void clear() {
+        SwingUtilities.invokeLater(() -> {
+            root.removeAllChildren();
+            stack.clear();
+            model.reload();
+        });
+    }
+
+    public void addNode(int level, String locator) {
+        SwingUtilities.invokeLater(() -> {
+            DefaultMutableTreeNode node = new DefaultMutableTreeNode(new NodeData(locator));
+            if (level == 0) {
+                root.add(node);
+                stack.clear();
+                stack.add(node);
+            } else {
+                while (stack.size() > level) {
+                    stack.remove(stack.size() - 1);
+                }
+                DefaultMutableTreeNode parent = stack.get(level - 1);
+                parent.add(node);
+                stack.add(node);
+            }
+            model.reload();
+        });
+    }
+
+    private static class NodeData {
+        final String locator;
+        NodeData(String locator) {
+            this.locator = locator;
+        }
+        @Override
+        public String toString() {
+            return locator;
+        }
+    }
+}
+

--- a/src/spyGui/SpyClientReader.java
+++ b/src/spyGui/SpyClientReader.java
@@ -52,6 +52,21 @@ public class SpyClientReader implements Runnable {
                     }
                     continue;
                 }
+                if (tempText.equals("TREE_BEGIN")) {
+                    SpyFrame.treePane.clear();
+                    continue;
+                }
+                if (tempText.startsWith("TREE,")) {
+                    String[] parts = tempText.split(",", 3);
+                    if (parts.length >= 3) {
+                        int level = Integer.parseInt(parts[1]);
+                        SpyFrame.treePane.addNode(level, parts[2]);
+                    }
+                    continue;
+                }
+                if (tempText.equals("TREE_END")) {
+                    continue;
+                }
                 SpyGuiPane.printText("Clear");
                 System.out.println("From Client: " + tempText);
                 String splitText[] = tempText.split(",");

--- a/src/spyGui/SpyFrame.java
+++ b/src/spyGui/SpyFrame.java
@@ -20,6 +20,7 @@ public class SpyFrame extends JFrame {
     private final CmdInputDlg launchDlg = new CmdInputDlg();
     private final SpyGuiPane displayPane = new SpyGuiPane();
     public static final RecordingPane recordingPane = new RecordingPane();
+    public static final ComponentTreePane treePane = new ComponentTreePane();
     private final JMenuBar menuBar = new JMenuBar();
     private final JMenuItem reindexItem = new JMenuItem("Reindex");
     private final JMenuItem recordItem = new JMenuItem("Record");
@@ -36,6 +37,7 @@ public class SpyFrame extends JFrame {
         JTabbedPane tabs = new JTabbedPane();
         tabs.addTab("Inspector", displayPane);
         tabs.addTab("Recording", recordingPane);
+        tabs.addTab("Elements", treePane);
 
         JPanel root = new JPanel(new BorderLayout());
         root.add(tabs, BorderLayout.CENTER);


### PR DESCRIPTION
## Summary
- add Elements tab displaying a hierarchical component tree
- support selecting tree nodes to highlight components and show properties
- enable agent to build and send tree data during reindexing

## Testing
- `javac @sources.list`

------
https://chatgpt.com/codex/tasks/task_e_68af8f005560832e881d8277bf5d5391